### PR TITLE
feat: github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: Build and Publish Ruby Gem on Tag Pushes
+on:
+  push:
+    tags:
+      - 'v*.*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build and Publish Ruby Gem on Tag Pushes
+      uses: bodyshopbidsdotcom/gh-action-publish-gem-on-tag@master
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        owner: ${{ github.repository_owner }}
+


### PR DESCRIPTION
In this PR:
* Added GitHub action  which can build and push gem from private repo to the [Github Packages Repository](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry). 

Prerequisites: 
* The repository name should mach `gem.name`  in `gemspec`
* Tag of pattern `v*.*.*.*`  should match gem version.
